### PR TITLE
yarn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+BATCH_SIZE ?= 2
+STEPS ?= 1000
+NGPU := $(shell nvidia-smi --list-gpus | wc -l)
+
+define run_fsdp
+	export NGPU=$(NGPU) && \
+	export CONFIG_FILE=$(1) && \
+	./run_llama_train.sh \
+		--training.batch_size $(BATCH_SIZE) \
+		--training.steps $(STEPS) \
+		--training.seq_len $(2)
+endef
+
+help:
+	@echo "Choose another target"
+
+fsdp:
+	$(call run_fsdp,./train_configs/debug_model.toml,2048)
+
+fsdp-yarn:
+	$(call run_fsdp,./train_configs/debug_yarn_model.toml,4096)

--- a/test/test_yarn.py
+++ b/test/test_yarn.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torchtitan.models.llama.model import (
@@ -17,3 +18,18 @@ def test_no_yarn_limit_equivalence():
         dim=dim, seq_len=seq_len, original_seq_len=original_seq_len
     )
     torch.testing.assert_close(freqs_llama, freqs_yarn)
+
+
+def test_yarn_different():
+    """
+    Expect different outputs when original_seq_len != seq_len
+    """
+    dim = 64
+    seq_len = 2048
+    original_seq_len = 1024
+    freqs_llama = _precompute_freqs_cis_original_llama(dim=dim, end=seq_len)
+    freqs_yarn = precompute_freqs_cis(
+        dim=dim, seq_len=seq_len, original_seq_len=original_seq_len
+    )
+    with pytest.raises(AssertionError, match="Mismatched elements"):
+        torch.testing.assert_close(freqs_llama, freqs_yarn)

--- a/test/test_yarn.py
+++ b/test/test_yarn.py
@@ -1,0 +1,19 @@
+import torch
+
+from torchtitan.models.llama.model import (
+    _precompute_freqs_cis_original_llama,
+    precompute_freqs_cis,
+)
+
+
+def test_no_yarn_limit_equivalence():
+    """
+    Expect the same outputs when original_seq_len == seq_len
+    """
+    dim = 64
+    seq_len = original_seq_len = 2048
+    freqs_llama = _precompute_freqs_cis_original_llama(dim=dim, end=seq_len)
+    freqs_yarn = precompute_freqs_cis(
+        dim=dim, seq_len=seq_len, original_seq_len=original_seq_len
+    )
+    torch.testing.assert_close(freqs_llama, freqs_yarn)

--- a/torchtitan/models/llama/__init__.py
+++ b/torchtitan/models/llama/__init__.py
@@ -12,6 +12,9 @@ __all__ = ["Transformer"]
 
 llama3_configs = {
     "debugmodel": ModelArgs(dim=256, n_layers=8, n_heads=16, rope_theta=500000),
+    "debugyarnmodel": ModelArgs(
+        dim=256, n_layers=8, n_heads=16, rope_theta=500000, original_seq_len=2048
+    ),
     "8B": ModelArgs(
         dim=4096,
         n_layers=32,

--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -36,10 +36,10 @@ class ModelArgs:
     depth_init: bool = True
     norm_type: str = "rmsnorm"
     # yarn: https://arxiv.org/pdf/2309.00071
-    original_seq_len: int = 4096
-    rope_factor: float = 40
-    beta_fast: int = 32
-    beta_slow: int = 1
+    original_seq_len: int = 2048
+    rope_factor: float = 40 # s in 2309.00071 (I believe); see eq (25)
+    beta_fast: int = 32 # \alpha in 2309.00071; see around eq (23)
+    beta_slow: int = 1 # \beta in 2309.00071; see around eq (23)
 
 
 def _precompute_freqs_cis_original_llama(

--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -35,7 +35,7 @@ class ModelArgs:
     # `False`, each uses the total number of transformer blocks
     depth_init: bool = True
     norm_type: str = "rmsnorm"
-    # yarn
+    # yarn: https://arxiv.org/pdf/2309.00071
     original_seq_len: int = 4096
     rope_factor: float = 40
     beta_fast: int = 32

--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -7,12 +7,14 @@
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
 
+import math
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
 import torch
 import torch.nn.functional as F
 from torch import nn
+
 from torchtitan.models.norms import build_norm
 
 
@@ -33,9 +35,16 @@ class ModelArgs:
     # `False`, each uses the total number of transformer blocks
     depth_init: bool = True
     norm_type: str = "rmsnorm"
+    # yarn
+    original_seq_len: int = 4096
+    rope_factor: float = 40
+    beta_fast: int = 32
+    beta_slow: int = 1
 
 
-def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0) -> torch.Tensor:
+def _precompute_freqs_cis_original_llama(
+    dim: int, end: int, theta: float = 10000.0
+) -> torch.Tensor:
     """
     Precompute the frequency tensor for complex exponentials (cis) with given dimensions.
 
@@ -55,6 +64,124 @@ def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0) -> torch.Te
     t = torch.arange(end, device=freqs.device)
     freqs = torch.outer(t, freqs).float()
     freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
+    return freqs_cis
+
+
+# Adapted from https://github.com/DeepSeek-ai/DeepSeek-V3/blob/main/inference/model.py#L294
+def precompute_freqs_cis(
+    dim: int,
+    seq_len: int,
+    original_seq_len: int,
+    rope_theta: float = 10000.0,
+    rope_factor: float = 40,
+    beta_fast: int = 32,
+    beta_slow: int = 1,
+) -> torch.Tensor:
+    """
+    Precomputes frequency-based complex exponential values for rotary positional embeddings.
+
+    Args:
+        dim (int): Dimension of the frequency tensor.
+        seqlen (int): the seqlen being trained on.
+        original_seq_len (int): the original training seqlen, if using YaRN to extend.
+        rope_theta (float, optional): Scaling factor for frequency computation. Defaults to 10000.0.
+        rope_factor (float): YaRN
+        beta_fast (int): YaRN
+        beta_slow (int): YaRN
+
+    Returns:
+        torch.Tensor: Precomputed complex exponential values for positional embeddings.
+
+    NOTE: DSv3 arg defaults:
+    # yarn
+    original_seq_len: int = 4096
+    rope_theta: float = 10000.0
+    rope_factor: float = 40
+    beta_fast: int = 32
+    beta_slow: int = 1
+
+    NOTE: @goon -  I omitted mscale which doesn't do anything when left at its default 1.0 value.
+    """
+
+    def find_correction_dim(
+        num_rotations: float, dim: int, base: float, max_seq_len: int
+    ) -> float:
+        """
+        Computes the correction dimension for a given number of rotations in the rotary positional embedding.
+
+        Args:
+            num_rotations (float): Number of rotations to compute the correction for.
+            dim (int): Dimensionality of the embedding space.
+            base (float): Base value for the exponential computation.
+            max_seq_len (int): Maximum sequence length.
+
+        Returns:
+            float: The correction dimension based on the input parameters.
+        """
+        return (
+            dim
+            * math.log(max_seq_len / (num_rotations * 2 * math.pi))
+            / (2 * math.log(base))
+        )
+
+    def find_correction_range(
+        low_rot: float, high_rot: float, dim: int, base: float, max_seq_len: int
+    ) -> Tuple[int, int]:
+        """
+        Computes the range of correction dimensions for rotary positional embeddings.
+
+        Args:
+            low_rot (float): Lower bound for the number of rotations.
+            high_rot (float): Upper bound for the number of rotations.
+            dim (int): Dimensionality of the embedding space.
+            base (float): Base value for the exponential computation.
+            max_seq_len (int): Maximum sequence length.
+
+        Returns:
+            Tuple[int, int]: The range of correction dimensions (low, high), clamped to valid indices.
+        """
+        low = math.floor(find_correction_dim(low_rot, dim, base, max_seq_len))
+        high = math.ceil(find_correction_dim(high_rot, dim, base, max_seq_len))
+        return max(low, 0), min(high, dim - 1)
+
+    def linear_ramp_factor(min: float, max: float, dim: int) -> torch.Tensor:
+        """
+        Computes a linear ramp function used to smooth values between a minimum and maximum range.
+
+        Args:
+            min (float): Minimum value for the ramp function.
+            max (float): Maximum value for the ramp function.
+            dim (int): Dimensionality of the ramp tensor.
+
+        Returns:
+            torch.Tensor: A tensor of shape (dim,) with values linearly interpolated between 0 and 1,
+                clamped to the range [0, 1].
+        """
+        if min == max:
+            max += 0.001
+        linear_func = (torch.arange(dim, dtype=torch.float32) - min) / (max - min)
+        ramp_func = torch.clamp(linear_func, 0, 1)
+        return ramp_func
+
+    # Basic RoPE frequency calculation
+    freqs = 1.0 / (rope_theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+
+    # YaRN scaling for extended context. YaRN is used to extend the context length after pre-training.
+    if seq_len > original_seq_len:
+        low, high = find_correction_range(
+            beta_fast, beta_slow, dim, rope_theta, original_seq_len
+        )
+        smooth = 1 - linear_ramp_factor(low, high, dim // 2)
+        freqs = freqs / rope_factor * (1 - smooth) + freqs * smooth
+
+    # Create position indices
+    t = torch.arange(seq_len)
+
+    # Outer product: [positions] × [frequencies]
+    freqs = torch.outer(t, freqs)
+
+    # Convert to complex exponentials: e^(i*freq*pos)
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
     return freqs_cis
 
 
@@ -416,12 +543,13 @@ class Transformer(nn.Module):
 
     def _precompute_freqs_cis(self) -> torch.Tensor:
         return precompute_freqs_cis(
-            self.model_args.dim // self.model_args.n_heads,
-            # Need to compute until at least the max token limit for generation
-            # TODO: explain in docs/composability.md why we removed the 2x
-            # relaxing in our CP enablement PR
-            self.model_args.max_seq_len,
-            self.model_args.rope_theta,
+            dim=self.model_args.dim // self.model_args.n_heads,
+            seq_len=self.model_args.max_seq_len,
+            original_seq_len=self.model_args.original_seq_len,
+            rope_theta=self.model_args.rope_theta,
+            rope_factor=self.model_args.rope_factor,
+            beta_fast=self.model_args.beta_fast,
+            beta_slow=self.model_args.beta_slow,
         )
 
     def forward(self, tokens: torch.Tensor):

--- a/train_configs/debug_yarn_model.toml
+++ b/train_configs/debug_yarn_model.toml
@@ -21,7 +21,7 @@ enable_wandb = false
 
 [model]
 name = "llama3"
-flavor = "debugmodel"
+flavor = "debugyarnmodel"
 norm_type = "rmsnorm"  # layernorm / np_layernorm / rmsnorm / fused_rmsnorm
 # test tokenizer.model, for debug purpose only
 tokenizer_path = "./test/assets/test_tiktoken.model"


### PR DESCRIPTION
Add [YaRN](https://arxiv.org/pdf/2309.00071) based on the [torchtitan dsv3 impl](https://github.com/garrett361/torchtitan/blob/a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41/torchtitan/models/deepseek_v3/model/model.py?plain=1#L58). 

Includes:
* tests of yarn equivlance when `seq_len == original_seq_len`
* a yarn debug model
* Makefile for verifying that the debug yarn model can be run e2e: `make fsdp-yarn` to run yarn model